### PR TITLE
 refactor: introduce NodeRef and adopt 64-bit xxhash for node IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	charm.land/bubbles/v2 v2.2.1
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/lipgloss/v2 v2.0.6
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/sagernet/netlink v0.0.0-20240612041022-b9a21c07ac6a
 	github.com/sagernet/sing v0.8.14
 	github.com/sagernet/sing-box v1.13.19

--- a/internal/client/cli/output.go
+++ b/internal/client/cli/output.go
@@ -58,13 +58,13 @@ func stateHeadline(st rpc.Status) {
 }
 
 func (a *app) statusFields(st rpc.Status, n rpc.Node) [][2]string {
-	f := [][2]string{{"Node", a.nodeName(st.NodeName, st.NodeID)}}
+	f := [][2]string{{"Node", a.nodeName(st.NodeName, st.NodeRef.NodeID)}}
 	f = append(f, a.nodeFields(n)...)
 	return f
 }
 
 func (a *app) nodeDetails(st rpc.Status) {
-	n, _ := a.resolveNode(st.NodeID)
+	n, _ := a.resolveNode(st.NodeRef.NodeID, st.NodeRef.SubscriptionID)
 	fields(a.statusFields(st, n)...)
 }
 
@@ -82,8 +82,10 @@ func (a *app) nodeName(name, id string) string {
 	if id == "" {
 		return a.clean(name)
 	}
-	return a.clean(name) + " " + style.Dim.Render("("+id+")")
+	return a.clean(name) + " " + style.Dim.Render("("+displayID(id)+")")
 }
+
+func displayID(id string) string { return id[:min(8, len(id))] }
 
 func modeWord(tun bool) string {
 	if tun {

--- a/internal/client/cli/root.go
+++ b/internal/client/cli/root.go
@@ -236,11 +236,11 @@ func match[T any](key, noun string, items []T, idName func(T) (id, name string))
 	for _, it := range items {
 		id, name := idName(it)
 		if id == key {
-			return it, nil // an id is never ambiguous
+			return it, nil
 		}
 		if strings.HasPrefix(id, key) || strings.Contains(strings.ToLower(name), key) {
 			hits = append(hits, it)
-			names = append(names, fmt.Sprintf("%s (%s)", style.Sanitize(name, true), id))
+			names = append(names, fmt.Sprintf("%s (%s)", style.Sanitize(name, true), displayID(id)))
 		}
 	}
 	switch len(hits) {

--- a/internal/client/cli/status.go
+++ b/internal/client/cli/status.go
@@ -22,11 +22,11 @@ func (a *app) status(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	id, err := a.client.Active()
-	if err != nil || id == "" {
+	ref, err := a.client.Active()
+	if err != nil || ref.NodeID == "" {
 		return nil
 	}
-	n, err := a.resolveNode(id)
+	n, err := a.resolveNode(ref.NodeID, ref.SubscriptionID)
 	if err != nil || n.ID == "" {
 		return nil
 	}

--- a/internal/client/cli/sub.go
+++ b/internal/client/cli/sub.go
@@ -142,7 +142,7 @@ func (a *app) showTree(subs []rpc.Sub, nodes []rpc.Node) {
 func (a *app) nodeLine(n rpc.Node, branch string, nameW, infoW int) string {
 	name := style.Pad(a.nodeName(n.Name, ""), nameW)
 	info := style.Dim.Render(style.Pad(a.serverProto(n), infoW))
-	id := style.Dim.Render(n.ID)
+	id := style.Dim.Render(displayID(n.ID))
 	if branch == "" {
 		return fmt.Sprintf("%s  %s  %s", a.nodeName(n.Name, ""), info, id)
 	}

--- a/internal/client/cli/up.go
+++ b/internal/client/cli/up.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -42,14 +43,18 @@ func (a *app) up(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	id, err := a.client.Active()
+	ref, err := a.client.Active()
 	if err != nil {
 		return err
 	}
-	if id == "" {
+	if ref.NodeID == "" {
 		return fmt.Errorf("no node selected yet; pick one: %s <id | name>", cmd.CommandPath())
 	}
-	return a.connectNode(id, mode)
+	n, err := a.resolveNode(ref.NodeID, ref.SubscriptionID)
+	if err != nil {
+		return err
+	}
+	return a.connect(n, mode)
 }
 
 func init() {
@@ -69,10 +74,14 @@ func tunMode(tun, proxy bool) *bool {
 }
 
 func (a *app) connectNode(key string, mode *bool) error {
-	n, err := a.resolveNode(key)
+	n, err := a.resolveNode(key, "")
 	if err != nil {
 		return err
 	}
+	return a.connect(n, mode)
+}
+
+func (a *app) connect(n rpc.Node, mode *bool) error {
 	spinText := "Connecting to " + a.clean(n.Name)
 	if mode != nil {
 		if _, err := a.runOp(spinText, func() (rpc.Status, error) { return a.client.SetTun(*mode) }, mode); err != nil {
@@ -80,7 +89,7 @@ func (a *app) connectNode(key string, mode *bool) error {
 		}
 	}
 	st, err := a.runOp(spinText, func() (rpc.Status, error) {
-		return a.client.Connect(n.ID)
+		return a.client.Connect(n.Ref())
 	}, mode)
 	if err != nil {
 		return err
@@ -150,10 +159,13 @@ func (a *app) report(headline string, st rpc.Status) {
 	a.warn(st.LastErr)
 }
 
-func (a *app) resolveNode(key string) (rpc.Node, error) {
+func (a *app) resolveNode(key, sub string) (rpc.Node, error) {
 	nodes, err := a.client.Nodes()
 	if err != nil {
 		return rpc.Node{}, err
+	}
+	if sub != "" {
+		nodes = slices.DeleteFunc(nodes, func(n rpc.Node) bool { return n.Sub != sub })
 	}
 	return match(key, "node", nodes, func(n rpc.Node) (string, string) { return n.ID, n.Name })
 }

--- a/internal/client/tui/actions.go
+++ b/internal/client/tui/actions.go
@@ -6,6 +6,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/luynrs/justray/internal/client/tui/tree"
+	"github.com/luynrs/justray/internal/shared/domain"
 	"github.com/luynrs/justray/internal/shared/rpc"
 )
 
@@ -25,9 +26,9 @@ func (m Model) activate() (tea.Model, tea.Cmd) {
 
 	m.connecting = true
 	act := m.client.Disconnect
-	if !m.connected() || m.status.NodeID != r.Node.ID {
-		id := r.Node.ID
-		act = func() (rpc.Status, error) { return m.client.Connect(id) }
+	if !m.connected() || m.status.NodeRef != r.Node.Ref() {
+		ref := r.Node.Ref()
+		act = func() (rpc.Status, error) { return m.client.Connect(ref) }
 	}
 	return m, tea.Batch(m.spin.Tick, connectCmd(func() error { _, err := act(); return err }))
 }
@@ -68,21 +69,21 @@ func (m Model) probe() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	m.probing = map[string]bool{}
+	m.probing = map[domain.NodeRef]bool{}
 	if r.Kind == tree.Node {
-		m.probing[r.Node.ID] = true
-		return m, probeCmd(m.client, "", r.Node.ID)
+		m.probing[r.Node.Ref()] = true
+		return m, probeCmd(m.client, r.Node.Sub, r.Node.ID)
 	}
 	for _, n := range m.data().SubNodes(r.Sub.ID) {
-		m.probing[n.ID] = true
+		m.probing[n.Ref()] = true
 	}
 	return m, probeCmd(m.client, r.Sub.ID, "")
 }
 
 func (m Model) probeAll() (tea.Model, tea.Cmd) {
-	m.probing = map[string]bool{}
+	m.probing = map[domain.NodeRef]bool{}
 	for _, n := range m.nodes {
-		m.probing[n.ID] = true
+		m.probing[n.Ref()] = true
 	}
 	return m, probeCmd(m.client, "", "")
 }

--- a/internal/client/tui/model.go
+++ b/internal/client/tui/model.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/luynrs/justray/internal/client/tui/settings"
 	"github.com/luynrs/justray/internal/client/tui/tree"
+	"github.com/luynrs/justray/internal/shared/domain"
 	"github.com/luynrs/justray/internal/shared/rpc"
 )
 
@@ -28,7 +29,7 @@ type Model struct {
 	nodes []rpc.Node
 
 	collapsed  map[string]bool
-	probing    map[string]bool
+	probing    map[domain.NodeRef]bool
 	refreshing map[string]bool
 	spin       spinner.Model
 	cursor     int

--- a/internal/client/tui/tree/nodes.go
+++ b/internal/client/tui/tree/nodes.go
@@ -53,9 +53,9 @@ func latency(n rpc.Node) string {
 
 func (d Data) dot(n rpc.Node) string {
 	switch {
-	case d.connected() && d.Status.NodeID == n.ID:
+	case d.connected() && d.Status.NodeRef == n.Ref():
 		return style.Strong.Render("●")
-	case d.Probing[n.ID]:
+	case d.Probing[n.Ref()]:
 		return style.Pending.Render("○")
 	case !n.Probed:
 		return style.Unknown.Render("○")

--- a/internal/client/tui/tree/tree.go
+++ b/internal/client/tui/tree/tree.go
@@ -3,6 +3,7 @@ package tree
 import (
 	"strings"
 
+	"github.com/luynrs/justray/internal/shared/domain"
 	"github.com/luynrs/justray/internal/shared/rpc"
 )
 
@@ -34,7 +35,7 @@ type Data struct {
 	Subs       []rpc.Sub
 	Nodes      []rpc.Node
 	Collapsed  map[string]bool
-	Probing    map[string]bool
+	Probing    map[domain.NodeRef]bool
 	Refreshing map[string]bool
 	Query      string
 	Status     rpc.Status
@@ -90,7 +91,7 @@ func (d Data) Rows() []Row {
 			rows = append(rows, Row{Kind: Meta, Sub: g.Sub})
 		}
 		for _, n := range nodes {
-			if q != "" || !d.Collapsed[g.Sub.ID] || (d.connected() && d.Status.NodeID == n.ID) {
+			if q != "" || !d.Collapsed[g.Sub.ID] || (d.connected() && d.Status.NodeRef == n.Ref()) {
 				rows = append(rows, Row{Kind: Node, Node: n})
 			}
 		}

--- a/internal/daemon/connection/manager.go
+++ b/internal/daemon/connection/manager.go
@@ -2,7 +2,9 @@ package connection
 
 import (
 	"errors"
+	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/luynrs/justray/internal/daemon/engine"
@@ -17,8 +19,8 @@ func (s *Service) Restore() {
 	defer s.opMu.Unlock()
 	defer s.broadcast()
 
-	id, err := s.store.Active()
-	if err != nil || id == "" {
+	ref, err := s.store.Active()
+	if err != nil || ref.NodeID == "" {
 		return
 	}
 	subs, err := s.store.Subscriptions()
@@ -26,11 +28,11 @@ func (s *Service) Restore() {
 		s.log.Print(err)
 		return
 	}
-	n, sub, ok := find(subs, id)
-	if !ok {
+	n, ref, err := find(subs, ref)
+	if err != nil {
 		return
 	}
-	if err := s.start(n, sub); err != nil {
+	if err := s.start(n, ref); err != nil {
 		s.log.Print(err)
 	}
 }
@@ -40,22 +42,22 @@ func (s *Service) ForgetIfRemoved(subID string, nodes []domain.Node) {
 	s.opMu.Lock()
 	defer s.opMu.Unlock()
 
-	gone := func(id string) bool {
-		return id != "" && slices.ContainsFunc(nodes, func(n domain.Node) bool { return n.ID == id })
+	gone := func(ref domain.NodeRef) bool {
+		return ref.NodeID != "" && (ref.SubscriptionID == subID || ref.SubscriptionID == "" && slices.ContainsFunc(nodes, func(n domain.Node) bool { return n.ID == ref.NodeID }))
 	}
 	if active, err := s.store.Active(); err == nil && gone(active) {
-		if err := s.store.SetActive(""); err != nil {
+		if err := s.store.SetActive(domain.NodeRef{}); err != nil {
 			s.log.Print(err)
 		}
 	}
 	if last, err := s.store.Last(); err == nil && gone(last) {
-		if err := s.store.SetLast(""); err != nil {
+		if err := s.store.SetLast(domain.NodeRef{}); err != nil {
 			s.log.Print(err)
 		}
 	}
 
 	s.mu.Lock()
-	live := s.session.sub == subID
+	live := s.session.ref.SubscriptionID == subID
 	name := s.session.node.Name
 	s.mu.Unlock()
 	if !live {
@@ -73,7 +75,7 @@ func (s *Service) ForgetIfRemoved(subID string, nodes []domain.Node) {
 	s.broadcast()
 }
 
-func (s *Service) start(n domain.Node, sub string) (err error) {
+func (s *Service) start(n domain.Node, ref domain.NodeRef) (err error) {
 	if n.TLS != nil && n.TLS.Insecure {
 		return errors.New("insecure TLS node is not allowed")
 	}
@@ -111,7 +113,7 @@ func (s *Service) start(n domain.Node, sub string) (err error) {
 	}
 	if err != nil {
 		if tun && elevate.Needed(err) {
-			s.persistActive(n.ID)
+			s.persistActive(ref)
 			s.requestRestart()
 			err = rpc.ErrElevate
 		}
@@ -120,11 +122,11 @@ func (s *Service) start(n domain.Node, sub string) (err error) {
 	}
 
 	s.mu.Lock()
-	s.session = session{eng: eng, node: n, sub: sub, started: time.Now(), tun: tun}
+	s.session = session{eng: eng, node: n, ref: ref, started: time.Now(), tun: tun}
 	s.lastErr = ""
 	s.mu.Unlock()
 
-	s.persistActive(n.ID)
+	s.persistActive(ref)
 	s.log.Printf("connected to %s (%s %s:%d)", n.Name, n.Protocol, n.Server, n.Port)
 	return nil
 }
@@ -167,7 +169,7 @@ func (s *Service) clear() error {
 	if err := s.stop(); err != nil {
 		return err
 	}
-	s.persistActive("")
+	s.persistActive(domain.NodeRef{})
 	return nil
 }
 
@@ -187,19 +189,34 @@ func (s *Service) setErr(err error) {
 	s.mu.Unlock()
 }
 
-func (s *Service) persistActive(id string) {
-	if err := s.store.SetActive(id); err != nil {
+func (s *Service) persistActive(ref domain.NodeRef) {
+	if err := s.store.SetActive(ref); err != nil {
 		s.log.Print(err)
 	}
 }
 
-func find(subs []store.Subscription, nodeID string) (domain.Node, string, bool) {
+func find(subs []store.Subscription, query domain.NodeRef) (domain.Node, domain.NodeRef, error) {
+	var node domain.Node
+	var ref domain.NodeRef
+	if query.NodeID == "" {
+		return node, ref, errors.New("node not found")
+	}
 	for _, sub := range subs {
+		if query.SubscriptionID != "" && sub.ID != query.SubscriptionID {
+			continue
+		}
 		for _, n := range sub.Nodes {
-			if n.ID == nodeID {
-				return n, sub.ID, true
+			if !strings.HasPrefix(n.ID, query.NodeID) {
+				continue
 			}
+			if ref.NodeID != "" {
+				return domain.Node{}, domain.NodeRef{}, fmt.Errorf("ambiguous node ID %q", query.NodeID)
+			}
+			node, ref = n, domain.NodeRef{SubscriptionID: sub.ID, NodeID: n.ID}
 		}
 	}
-	return domain.Node{}, "", false
+	if ref.NodeID == "" {
+		return node, ref, fmt.Errorf("node %q not found", query.NodeID)
+	}
+	return node, ref, nil
 }

--- a/internal/daemon/connection/manager_test.go
+++ b/internal/daemon/connection/manager_test.go
@@ -28,7 +28,7 @@ func testService(t *testing.T, eng engine.Engine) *Service {
 	return &Service{
 		store: store.Disk{Dir: t.TempDir()}, log: log.New(io.Discard, "", 0),
 		settings: settings, session: session{eng: eng},
-		watchers: map[chan Status]struct{}{}, probes: map[string]engine.Result{},
+		watchers: map[chan Status]struct{}{}, probes: map[domain.NodeRef]engine.Result{},
 	}
 }
 
@@ -68,8 +68,25 @@ func TestStartClosesEngineOnFailure(t *testing.T) {
 	eng := &fakeEngine{startErr: errors.New("start failed")}
 	s := testService(t, nil)
 	s.newEngine = func(domain.Settings, string) engine.Engine { return eng }
-	if err := s.start(domain.Node{ID: "n1"}, ""); err == nil || eng.closeCalls != 1 {
+	if err := s.start(domain.Node{ID: "n1"}, domain.NodeRef{NodeID: "n1"}); err == nil || eng.closeCalls != 1 {
 		t.Fatalf("start err=%v closeCalls=%d", err, eng.closeCalls)
+	}
+}
+
+func TestFind(t *testing.T) {
+	subs := []store.Subscription{
+		{ID: "a", Nodes: []domain.Node{{ID: "0123456789abcdef"}}},
+		{ID: "b", Nodes: []domain.Node{{ID: "0123fedcba987654"}}},
+	}
+	if _, _, err := find(subs, domain.NodeRef{NodeID: "ffff"}); err == nil || err.Error() != `node "ffff" not found` {
+		t.Fatalf("missing node: %v", err)
+	}
+	if _, _, err := find(subs, domain.NodeRef{NodeID: "0123"}); err == nil || err.Error() != `ambiguous node ID "0123"` {
+		t.Fatalf("ambiguous node: %v", err)
+	}
+	_, ref, err := find(subs, domain.NodeRef{NodeID: "01234567"})
+	if err != nil || ref != (domain.NodeRef{SubscriptionID: "a", NodeID: "0123456789abcdef"}) {
+		t.Fatalf("unique node: ref=%+v err=%v", ref, err)
 	}
 }
 

--- a/internal/daemon/connection/probe.go
+++ b/internal/daemon/connection/probe.go
@@ -3,7 +3,6 @@ package connection
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	"github.com/luynrs/justray/internal/shared/domain"
 	"github.com/luynrs/justray/internal/shared/rpc"
@@ -20,12 +19,13 @@ func (s *Service) Nodes() ([]rpc.Node, error) {
 	out := []rpc.Node{} // never nil: the TUI tells "no nodes" from "not loaded yet"
 	for _, sub := range subs {
 		for _, n := range sub.Nodes {
+			ref := domain.NodeRef{SubscriptionID: sub.ID, NodeID: n.ID}
 			item := rpc.Node{
 				ID: n.ID, Name: n.Name, Protocol: string(n.Protocol),
 				Server: n.Server, Port: n.Port,
 				Sub: sub.ID,
 			}
-			if p, ok := s.probes[n.ID]; ok {
+			if p, ok := s.probes[ref]; ok {
 				item.Probed, item.Alive, item.MS = true, p.Alive, p.MS
 			}
 			out = append(out, item)
@@ -41,13 +41,15 @@ func (s *Service) Probe(ctx context.Context, sub, id string) ([]rpc.Node, error)
 		return nil, err
 	}
 
+	live := map[domain.NodeRef]bool{}
+	var refs []domain.NodeRef
 	var targets []domain.Node
 	for _, x := range subs {
-		if sub != "" && x.ID != sub {
-			continue
-		}
 		for _, n := range x.Nodes {
-			if id == "" || n.ID == id {
+			ref := domain.NodeRef{SubscriptionID: x.ID, NodeID: n.ID}
+			live[ref] = true
+			if (sub == "" || x.ID == sub) && (id == "" || n.ID == id) {
+				refs = append(refs, ref)
 				targets = append(targets, n)
 			}
 		}
@@ -61,18 +63,15 @@ func (s *Service) Probe(ctx context.Context, sub, id string) ([]rpc.Node, error)
 		return nil, err
 	}
 
-	live := map[string]bool{}
-	for _, x := range subs {
-		for _, n := range x.Nodes {
-			live[n.ID] = true
+	s.mu.Lock()
+	for _, ref := range refs {
+		if result, ok := results[ref.NodeID]; ok {
+			s.probes[ref] = result
 		}
 	}
-
-	s.mu.Lock()
-	maps.Copy(s.probes, results)
-	for id := range s.probes {
-		if !live[id] {
-			delete(s.probes, id)
+	for ref := range s.probes {
+		if !live[ref] {
+			delete(s.probes, ref)
 		}
 	}
 	s.mu.Unlock()

--- a/internal/daemon/connection/service.go
+++ b/internal/daemon/connection/service.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -31,7 +30,7 @@ type Service struct {
 	lastErr  string
 	tun      bool
 	settings domain.Settings
-	probes   map[string]engine.Result
+	probes   map[domain.NodeRef]engine.Result
 
 	watchers map[chan Status]struct{}
 	restart  chan struct{}
@@ -56,7 +55,7 @@ func New(dir string, st store.Disk, newEngine engine.New, probe engine.Probe, lo
 		dir:       dir,
 		tun:       state.Tun,
 		settings:  settings,
-		probes:    map[string]engine.Result{},
+		probes:    map[domain.NodeRef]engine.Result{},
 		watchers:  map[chan Status]struct{}{},
 		restart:   make(chan struct{}, 1),
 	}
@@ -115,7 +114,7 @@ func (s *Service) SetSettings(in domain.Settings) (Status, error) {
 	if err := s.stop(); err != nil {
 		return s.finish(err)
 	}
-	return s.finish(s.start(cur.node, cur.sub))
+	return s.finish(s.start(cur.node, cur.ref))
 }
 
 func engineChanged(x, y domain.Settings) bool {
@@ -126,7 +125,7 @@ func engineChanged(x, y domain.Settings) bool {
 	return !x.Equal(y)
 }
 
-func (s *Service) Connect(id string) (Status, error) {
+func (s *Service) Connect(queryID, subID string) (Status, error) {
 	s.opMu.Lock()
 	defer s.opMu.Unlock()
 
@@ -134,12 +133,12 @@ func (s *Service) Connect(id string) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	n, sub, ok := find(subs, id)
-	if !ok {
-		return Status{}, fmt.Errorf("node %q not found", id)
+	n, ref, err := find(subs, domain.NodeRef{SubscriptionID: subID, NodeID: queryID})
+	if err != nil {
+		return Status{}, err
 	}
 
-	return s.finish(s.start(n, sub))
+	return s.finish(s.start(n, ref))
 }
 
 func (s *Service) Disconnect() (Status, error) {
@@ -227,11 +226,11 @@ func (s *Service) Shutdown() {
 	}
 }
 
-// ActiveID returns the connected node id, or the last one used, or "" if none.
-func (s *Service) ActiveID() (string, error) {
-	id, err := s.store.Active()
-	if id != "" || err != nil {
-		return id, err
+// ActiveRef returns the connected node, the last one used, or zero if none.
+func (s *Service) ActiveRef() (domain.NodeRef, error) {
+	ref, err := s.store.Active()
+	if ref.NodeID != "" || err != nil {
+		return ref, err
 	}
 	return s.store.Last()
 }
@@ -246,7 +245,7 @@ func (s *Service) status() Status {
 	st := Status{Port: s.settings.Port, Tun: s.tun, LastErr: s.lastErr}
 	if s.session.eng != nil {
 		st.Connected = true
-		st.NodeID, st.NodeName = s.session.node.ID, s.session.node.Name
+		st.NodeRef, st.NodeName = s.session.ref, s.session.node.Name
 		st.Uptime = int64(time.Since(s.session.started).Seconds())
 	}
 	return st

--- a/internal/daemon/connection/state.go
+++ b/internal/daemon/connection/state.go
@@ -10,7 +10,7 @@ import (
 type session struct {
 	eng     engine.Engine
 	node    domain.Node
-	sub     string
+	ref     domain.NodeRef
 	started time.Time
 	tun     bool // the tun the engine has
 }

--- a/internal/daemon/server/handlers.go
+++ b/internal/daemon/server/handlers.go
@@ -42,7 +42,7 @@ func (s *Server) dispatch(req rpc.Req) (any, error) {
 	case "Status":
 		return s.conn.Status(), nil
 	case "Active":
-		return s.conn.ActiveID()
+		return s.conn.ActiveRef()
 	case "Subs":
 		return s.subs.List()
 	case "AddSub":
@@ -60,7 +60,7 @@ func (s *Server) dispatch(req rpc.Req) (any, error) {
 	case "Probe":
 		return s.conn.Probe(s.ctx, a.Sub, a.ID)
 	case "Connect":
-		return s.conn.Connect(a.ID)
+		return s.conn.Connect(a.ID, a.Sub)
 	case "Disconnect":
 		return s.conn.Disconnect()
 	case "SetTun":

--- a/internal/daemon/store/store.go
+++ b/internal/daemon/store/store.go
@@ -22,10 +22,12 @@ type Subscription struct {
 }
 
 type State struct {
-	Active   string          `yaml:"active"`
-	Last     string          `yaml:"last,omitempty"`
-	Tun      bool            `yaml:"tun,omitempty"`
-	Settings domain.Settings `yaml:"settings,omitempty"`
+	Active    string          `yaml:"active"`
+	ActiveSub string          `yaml:"active_subscription,omitempty"`
+	Last      string          `yaml:"last,omitempty"`
+	LastSub   string          `yaml:"last_subscription,omitempty"`
+	Tun       bool            `yaml:"tun,omitempty"`
+	Settings  domain.Settings `yaml:"settings,omitempty"`
 }
 
 // Disk reads and writes subscriptions.yaml and configuration.yaml
@@ -64,28 +66,28 @@ func (d Disk) State() (State, error) {
 	return s, yaml.Unmarshal(data, &s)
 }
 
-func (d Disk) Active() (string, error) {
+func (d Disk) Active() (domain.NodeRef, error) {
 	s, err := d.State()
-	return s.Active, err
+	return domain.NodeRef{SubscriptionID: s.ActiveSub, NodeID: s.Active}, err
 }
 
 // SetActive persists the node to restore on start; connecting also records it as Last
-func (d Disk) SetActive(id string) error {
+func (d Disk) SetActive(ref domain.NodeRef) error {
 	return d.update(func(s *State) {
-		s.Active = id
-		if id != "" {
-			s.Last = id
+		s.Active, s.ActiveSub = ref.NodeID, ref.SubscriptionID
+		if ref.NodeID != "" {
+			s.Last, s.LastSub = ref.NodeID, ref.SubscriptionID
 		}
 	})
 }
 
-func (d Disk) Last() (string, error) {
+func (d Disk) Last() (domain.NodeRef, error) {
 	s, err := d.State()
-	return s.Last, err
+	return domain.NodeRef{SubscriptionID: s.LastSub, NodeID: s.Last}, err
 }
 
-func (d Disk) SetLast(id string) error {
-	return d.update(func(s *State) { s.Last = id })
+func (d Disk) SetLast(ref domain.NodeRef) error {
+	return d.update(func(s *State) { s.Last, s.LastSub = ref.NodeID, ref.SubscriptionID })
 }
 
 func (d Disk) SetTun(on bool) error {

--- a/internal/daemon/store/store_test.go
+++ b/internal/daemon/store/store_test.go
@@ -40,21 +40,22 @@ func TestStore(t *testing.T) {
 
 	t.Run("active", func(t *testing.T) {
 		d := Disk{Dir: t.TempDir()}
+		ref := domain.NodeRef{SubscriptionID: "sub1", NodeID: "node1"}
 
-		if id, err := d.Active(); err != nil || id != "" {
-			t.Fatalf("empty dir: got %q, %v; want \"\", nil", id, err)
+		if got, err := d.Active(); err != nil || got != (domain.NodeRef{}) {
+			t.Fatalf("empty dir: got %+v, %v; want zero ref, nil", got, err)
 		}
-		if err := d.SetActive("node1"); err != nil {
+		if err := d.SetActive(ref); err != nil {
 			t.Fatalf("SetActive: %v", err)
 		}
-		if id, err := d.Active(); err != nil || id != "node1" {
-			t.Fatalf("got %q, %v; want \"node1\", nil", id, err)
+		if got, err := d.Active(); err != nil || got != ref {
+			t.Fatalf("got %+v, %v; want %+v, nil", got, err, ref)
 		}
-		if err := d.SetActive(""); err != nil {
+		if err := d.SetActive(domain.NodeRef{}); err != nil {
 			t.Fatalf("SetActive(\"\"): %v", err)
 		}
-		if id, err := d.Last(); err != nil || id != "node1" {
-			t.Fatalf("disconnect forgot the last node: got %q, %v; want \"node1\", nil", id, err)
+		if got, err := d.Last(); err != nil || got != ref {
+			t.Fatalf("disconnect forgot the last node: got %+v, %v; want %+v, nil", got, err, ref)
 		}
 	})
 

--- a/internal/shared/domain/node.go
+++ b/internal/shared/domain/node.go
@@ -38,6 +38,11 @@ type Node struct {
 	WireGuard      *WireGuard
 }
 
+type NodeRef struct {
+	SubscriptionID string
+	NodeID         string
+}
+
 func ValidPort(port int) bool { return port >= 1 && port <= 65535 }
 
 type Auth struct {

--- a/internal/shared/parser/parser_test.go
+++ b/internal/shared/parser/parser_test.go
@@ -57,8 +57,8 @@ func TestParseURI(t *testing.T) {
 			if n.Protocol != c.protocol || n.Server != c.server || n.Port != c.port {
 				t.Fatalf("got %s %s:%d, want %s %s:%d", n.Protocol, n.Server, n.Port, c.protocol, c.server, c.port)
 			}
-			if n.ID == "" {
-				t.Fatal("empty node ID")
+			if len(n.ID) != 16 {
+				t.Fatalf("node ID %q has length %d, want 16", n.ID, len(n.ID))
 			}
 			if c.protocol == domain.WG && (n.WireGuard == nil || len(n.WireGuard.Address) == 0) {
 				t.Fatal("missing WireGuard settings")

--- a/internal/shared/parser/protocols/util.go
+++ b/internal/shared/parser/protocols/util.go
@@ -2,9 +2,7 @@ package protocols
 
 import (
 	"cmp"
-	"crypto/sha1"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -12,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/luynrs/justray/internal/shared/domain"
 )
 
@@ -24,34 +23,10 @@ func Unbase64(s string) ([]byte, error) {
 	return base64.RawStdEncoding.DecodeString(s)
 }
 
-func id(raw string) string {
-	sum := sha1.Sum([]byte(raw))
-	return hex.EncodeToString(sum[:])[:8]
-}
-
 func NodeID(n domain.Node) string {
-	wg := ""
-	if n.WireGuard != nil {
-		wg = n.WireGuard.PrivateKey + n.WireGuard.PeerPublicKey
-	}
-	tls := ""
-	if n.TLS != nil {
-		tls = n.TLS.SNI + strings.Join(n.TLS.ALPN, ",") + n.TLS.Fingerprint
-	}
-	reality := ""
-	if n.Reality != nil {
-		reality = n.Reality.PublicKey + n.Reality.ShortID
-	}
-	shadowTLS := ""
-	if n.ShadowTLS != nil {
-		shadowTLS = fmt.Sprintf("%d:%s:%s", n.ShadowTLS.Version, n.ShadowTLS.Password, n.ShadowTLS.SNI)
-	}
-	return id(strings.Join([]string{
-		string(n.Protocol), n.Server, strconv.Itoa(n.Port),
-		n.Auth.UUID, n.Auth.Password, n.Auth.Username,
-		n.Transport.Network, n.Transport.Path, n.Transport.Host, n.Transport.ServiceName,
-		tls, reality, wg, shadowTLS,
-	}, "|"))
+	n.ID, n.Name = "", ""
+	data, _ := json.Marshal(n)
+	return fmt.Sprintf("%016x", xxhash.Sum64(data))
 }
 
 func parseURL(proto, uri string) (*url.URL, string, int, error) {

--- a/internal/shared/rpc/client.go
+++ b/internal/shared/rpc/client.go
@@ -56,11 +56,11 @@ func call[T any](c *Client, method string, args Args) (T, error) {
 	return out, nil
 }
 
-func (c *Client) Ping() error                    { _, err := call[any](c, "Ping", Args{}); return err }
-func (c *Client) Status() (Status, error)        { return call[Status](c, "Status", Args{}) }
-func (c *Client) Active() (string, error)        { return call[string](c, "Active", Args{}) }
-func (c *Client) Subs() ([]Sub, error)           { return call[[]Sub](c, "Subs", Args{}) }
-func (c *Client) AddSub(url string) (Sub, error) { return call[Sub](c, "AddSub", Args{URL: url}) }
+func (c *Client) Ping() error                     { _, err := call[any](c, "Ping", Args{}); return err }
+func (c *Client) Status() (Status, error)         { return call[Status](c, "Status", Args{}) }
+func (c *Client) Active() (domain.NodeRef, error) { return call[domain.NodeRef](c, "Active", Args{}) }
+func (c *Client) Subs() ([]Sub, error)            { return call[[]Sub](c, "Subs", Args{}) }
+func (c *Client) AddSub(url string) (Sub, error)  { return call[Sub](c, "AddSub", Args{URL: url}) }
 func (c *Client) RemoveSub(id string) error {
 	_, err := call[any](c, "RemoveSub", Args{ID: id})
 	return err
@@ -69,11 +69,13 @@ func (c *Client) MoveSub(id string, dir int) error {
 	_, err := call[any](c, "MoveSub", Args{ID: id, Dir: dir})
 	return err
 }
-func (c *Client) RefreshAll() ([]Sub, error)        { return call[[]Sub](c, "RefreshAll", Args{}) }
-func (c *Client) Refresh(id string) (Sub, error)    { return call[Sub](c, "Refresh", Args{ID: id}) }
-func (c *Client) Nodes() ([]Node, error)            { return call[[]Node](c, "Nodes", Args{}) }
-func (c *Client) Connect(id string) (Status, error) { return call[Status](c, "Connect", Args{ID: id}) }
-func (c *Client) Disconnect() (Status, error)       { return call[Status](c, "Disconnect", Args{}) }
+func (c *Client) RefreshAll() ([]Sub, error)     { return call[[]Sub](c, "RefreshAll", Args{}) }
+func (c *Client) Refresh(id string) (Sub, error) { return call[Sub](c, "Refresh", Args{ID: id}) }
+func (c *Client) Nodes() ([]Node, error)         { return call[[]Node](c, "Nodes", Args{}) }
+func (c *Client) Connect(ref domain.NodeRef) (Status, error) {
+	return call[Status](c, "Connect", Args{ID: ref.NodeID, Sub: ref.SubscriptionID})
+}
+func (c *Client) Disconnect() (Status, error) { return call[Status](c, "Disconnect", Args{}) }
 
 func (c *Client) Probe(sub, id string) ([]Node, error) {
 	return call[[]Node](c, "Probe", Args{Sub: sub, ID: id})

--- a/internal/shared/rpc/types.go
+++ b/internal/shared/rpc/types.go
@@ -53,9 +53,13 @@ type Node struct {
 	MS     int
 }
 
+func (n Node) Ref() domain.NodeRef {
+	return domain.NodeRef{SubscriptionID: n.Sub, NodeID: n.ID}
+}
+
 type Status struct {
 	Connected bool
-	NodeID    string
+	NodeRef   domain.NodeRef
 	NodeName  string
 	Uptime    int64 // seconds
 	LastErr   string


### PR DESCRIPTION
 - SHA1 with xxhash
    - Introduce domain.NodeRef to scope and disambiguate nodes across subscriptions
    - Add helper to show 8-char prefixes in CLI and TUI