### PR TITLE
docs: Add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yay -S justray-bin
 
 ```
 
-Or via [x-cmd](https://www.x-cmd.com/mod/eget):
+Maybe using [x-cmd](https://www.x-cmd.com/mod/eget):
 
 ```bash
 x eget use luynrs/justray

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ yay -S justray-bin
 
 ```
 
+Or via [x-cmd](https://www.x-cmd.com/mod/eget):
+
+```bash
+x eget use luynrs/justray
+```
+
 Or via script:
 
 ```bash


### PR DESCRIPTION
Add `x eget` as an installation method for justray.

`x eget` allows users to install justray directly from its GitHub release:

```sh
x eget use luynrs/justray
```